### PR TITLE
Enable code splitting with Vite

### DIFF
--- a/app/frontend/entrypoints/inertia.ts
+++ b/app/frontend/entrypoints/inertia.ts
@@ -1,12 +1,12 @@
-import { createInertiaApp } from '@inertiajs/react'
-import { createElement, ReactNode } from 'react'
-import { createRoot } from 'react-dom/client'
+import { createInertiaApp } from "@inertiajs/react";
+import { createElement, ReactNode } from "react";
+import { createRoot } from "react-dom/client";
 
 // Temporary type definition, until @inertiajs/react provides one
 type ResolvedComponent = {
-  default: ReactNode
-  layout?: (page: ReactNode) => ReactNode
-}
+  default: ReactNode;
+  layout?: (page: ReactNode) => ReactNode;
+};
 
 createInertiaApp({
   // Set default page title
@@ -20,12 +20,10 @@ createInertiaApp({
   // progress: false,
 
   resolve: (name) => {
-    const pages = import.meta.glob<ResolvedComponent>('../pages/**/*.tsx', {
-      eager: true,
-    })
-    const page = pages[`../pages/${name}.tsx`]
+    const pages = import.meta.glob<ResolvedComponent>("../pages/**/*.tsx");
+    const page = pages[`../pages/${name}.tsx`];
     if (!page) {
-      console.error(`Missing Inertia page component: '${name}.tsx'`)
+      console.error(`Missing Inertia page component: '${name}.tsx'`);
     }
 
     // To use a default layout, import the Layout component
@@ -34,18 +32,18 @@ createInertiaApp({
     //
     // page.default.layout ||= (page) => createElement(Layout, null, page)
 
-    return page
+    return page;
   },
 
   setup({ el, App, props }) {
     if (el) {
-      createRoot(el).render(createElement(App, props))
+      createRoot(el).render(createElement(App, props));
     } else {
       console.error(
-        'Missing root element.\n\n' +
-          'If you see this error, it probably means you load Inertia.js on non-Inertia pages.\n' +
-          'Consider moving <%= vite_typescript_tag "inertia" %> to the Inertia-specific layout instead.',
-      )
+        "Missing root element.\n\n" +
+          "If you see this error, it probably means you load Inertia.js on non-Inertia pages.\n" +
+          'Consider moving <%= vite_typescript_tag "inertia" %> to the Inertia-specific layout instead.'
+      );
     }
   },
-})
+});


### PR DESCRIPTION
# What is changing
By default, `inertia-rails` seems to send a single js bundle with code for the whole app included. From their docs [here](https://inertia-rails.dev/guide/code-splitting#using-vite), you can enable code splitting in Vite by either omitting an option or setting it to false, here I opted to omit it.