### PR TITLE
Adds "gomi_guesser" routes to routes.rb

### DIFF
--- a/app/frontend/pages/Landing.tsx
+++ b/app/frontend/pages/Landing.tsx
@@ -1,0 +1,12 @@
+import { Head } from "@inertiajs/react";
+
+export default function InertiaExample() {
+  return (
+    <>
+      <Head title="Inertia + Vite Ruby + React Example" />
+      <div>
+        <h1>Landing page</h1>
+      </div>
+    </>
+  );
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,12 @@
 Rails.application.routes.draw do
-  get 'inertia-example', to: 'inertia_example#index'
+  inertia "/" => "Landing"
+
+  namespace "gomi_guesser" do
+    inertia "/" => "Landing"
+    inertia "/test" => "Landing"
+  end
+
+  get "inertia-example", to: "inertia_example#index"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
### What changed, and _why_?
Adds a namespace in `routes.rb` and includes placeholder page component to prove that the routing works how I expect it to. Can hit `"/gomi_guesser"` and `/gomi_guesser/test"` to see the placeholder pages.
