### PR TITLE
Trying to get sunasuna.cafe to serve https traffic

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -19,7 +19,9 @@ servers:
 # Note: If using Cloudflare, set encryption mode in SSL/TLS setting to "Full" to enable CF-to-app encryption.
 proxy:
   ssl: true
-  host: www.sunasuna.cafe
+  hosts:
+    - www.sunasuna.cafe
+    - sunasuna.cafe
 
 # Credentials for your image host.
 registry:


### PR DESCRIPTION
### What changed, and _why_?
Updated `deploy.yml` to add `sunasuna.cafe` as a proxy host, was originally just `www.sunasuna.cafe`. Alongside this code change, also added an A record on our domain provider pointing `sunasuna.cafe` to the vps public IP.

### Any other considerations
I'm honestly not sure if this will do what I want it to, but I don't think there would be any lasting implications, maybe incorrect dns gets cached for a little bit.