### PR TITLE
Revert "Enable code splitting with Vite"

### DIFF
--- a/app/frontend/entrypoints/inertia.ts
+++ b/app/frontend/entrypoints/inertia.ts
@@ -1,12 +1,12 @@
-import { createInertiaApp } from "@inertiajs/react";
-import { createElement, ReactNode } from "react";
-import { createRoot } from "react-dom/client";
+import { createInertiaApp } from '@inertiajs/react'
+import { createElement, ReactNode } from 'react'
+import { createRoot } from 'react-dom/client'
 
 // Temporary type definition, until @inertiajs/react provides one
 type ResolvedComponent = {
-  default: ReactNode;
-  layout?: (page: ReactNode) => ReactNode;
-};
+  default: ReactNode
+  layout?: (page: ReactNode) => ReactNode
+}
 
 createInertiaApp({
   // Set default page title
@@ -20,10 +20,12 @@ createInertiaApp({
   // progress: false,
 
   resolve: (name) => {
-    const pages = import.meta.glob<ResolvedComponent>("../pages/**/*.tsx");
-    const page = pages[`../pages/${name}.tsx`];
+    const pages = import.meta.glob<ResolvedComponent>('../pages/**/*.tsx', {
+      eager: true,
+    })
+    const page = pages[`../pages/${name}.tsx`]
     if (!page) {
-      console.error(`Missing Inertia page component: '${name}.tsx'`);
+      console.error(`Missing Inertia page component: '${name}.tsx'`)
     }
 
     // To use a default layout, import the Layout component
@@ -32,18 +34,18 @@ createInertiaApp({
     //
     // page.default.layout ||= (page) => createElement(Layout, null, page)
 
-    return page;
+    return page
   },
 
   setup({ el, App, props }) {
     if (el) {
-      createRoot(el).render(createElement(App, props));
+      createRoot(el).render(createElement(App, props))
     } else {
       console.error(
-        "Missing root element.\n\n" +
-          "If you see this error, it probably means you load Inertia.js on non-Inertia pages.\n" +
-          'Consider moving <%= vite_typescript_tag "inertia" %> to the Inertia-specific layout instead.'
-      );
+        'Missing root element.\n\n' +
+          'If you see this error, it probably means you load Inertia.js on non-Inertia pages.\n' +
+          'Consider moving <%= vite_typescript_tag "inertia" %> to the Inertia-specific layout instead.',
+      )
     }
   },
-});
+})


### PR DESCRIPTION
Reverts kinoko-empire/gomi_guesser#12

Had to do this because React was erroring out after the change with the following error:
```
Uncaught Error: An unknown Component is an async Client Component. Only Server Components can be async at the moment. This error is often caused by accidentally adding `'use client'` to a module that was originally written for the server.
```
Odd because not using `'use client'` anywhere.