### PR TITLE
Create users migration

### DIFF
--- a/db/migrate/20251123223239_create_users.rb
+++ b/db/migrate/20251123223239_create_users.rb
@@ -1,0 +1,14 @@
+class CreateUsers < ActiveRecord::Migration[8.0]
+  def change
+    create_table :users do |t|
+      t.string :email, null: false
+      t.string :username, null: false
+      t.string :password_digest, null: false
+      # using enums in sqlite and rails - https://jasonchee.me/notes/enum-with-sqlite/
+      t.string :role, null: false, default: "standard"
+      t.check_constraint "role IN ('standard', 'admin')", name: "role_check"
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,5 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 0) do
+ActiveRecord::Schema[8.0].define(version: 2025_11_23_223239) do
+  create_table "users", force: :cascade do |t|
+    t.string "email", null: false
+    t.string "username", null: false
+    t.string "password_digest", null: false
+    t.string "role", default: "standard", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.check_constraint "role IN ('standard', 'admin')", name: "role_check"
+  end
 end


### PR DESCRIPTION
### What changed, and _why_?
Created and ran the migration for creating a `Users` table.

### Screenshots (if relevant)

### Any other considerations
Unsure how to run the migrations on the prod vps using Kamal, and also not sure if the prod sqlite db file currently gets persisted on the prod machine or gets reset every time. Based on what I've read at least, seems like Kamal will automatically run pending migrations.
