### PR TITLE
Add the "item_categories" table and runs migration

### DIFF
--- a/db/migrate/20251211230434_create_item_categories.rb
+++ b/db/migrate/20251211230434_create_item_categories.rb
@@ -1,0 +1,12 @@
+class CreateItemCategories < ActiveRecord::Migration[8.0]
+  def change
+    create_table :item_categories do |t|
+      t.string :name, null: false
+      t.string :kanji_name, null: false
+      t.string :kana_name, null: false
+      t.boolean :recyclable, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_12_03_231924) do
+ActiveRecord::Schema[8.0].define(version: 2025_12_11_230434) do
+  create_table "item_categories", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "kanji_name", null: false
+    t.string "kana_name", null: false
+    t.boolean "recyclable", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "items", force: :cascade do |t|
     t.string "eng_name", null: false
     t.string "kana_name"


### PR DESCRIPTION
### What changed, and _why_?
Adds the `item_categories` table to add to the relationship between `items` and `municipalities` - this table is meant to indicate the category of waste that an item may be classified as, and this category depends on the municipality. I still need to add the table that relates all three of these tables together, tentatively called `item_rules`.

### Screenshots (if relevant)
LucidChart screenshot and link [here](https://lucid.app/lucidchart/060047b9-997c-40c6-8178-984276a9a543/edit?viewport_loc=-1930%2C614%2C2301%2C1266%2C0_0&invitationId=inv_f28d1dec-6055-4867-acf0-289df0d3c331). This shows the relationship between `items`, `item_categories`, `municipalities`, and the proposed `item_rules` table.
<img width="966" height="577" alt="Screenshot 2025-12-13 at 12 17 46 AM" src="https://github.com/user-attachments/assets/c5f0d5ea-7cea-4301-a380-5a0324646725" />

### Any other considerations
