### PR TITLE
Adds a unique index to items.eng_name

### DIFF
--- a/db/migrate/20251214202553_add_unique_index_to_item_eng_name.rb
+++ b/db/migrate/20251214202553_add_unique_index_to_item_eng_name.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToItemEngName < ActiveRecord::Migration[8.0]
+  def change
+    add_index(:items, :eng_name, unique: true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_12_11_230434) do
+ActiveRecord::Schema[8.0].define(version: 2025_12_14_202553) do
   create_table "item_categories", force: :cascade do |t|
     t.string "name", null: false
     t.string "kanji_name", null: false
@@ -26,6 +26,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_11_230434) do
     t.string "kanji_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["eng_name"], name: "index_items_on_eng_name", unique: true
   end
 
   create_table "municipalities", force: :cascade do |t|


### PR DESCRIPTION
### What changed, and _why_?
As the title implies, adds a unique index to `items.eng_name` column to ensure it is a unique value. I would hope that this also speeds up queries that join on the `eng_name` or when querying by the name directly, but would need to verify that in the database when those queries actually start happening.

### Screenshots (if relevant)

### Any other considerations
