### PR TITLE
Create admin dashboard and pages for items, municipalities and prefectures

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,0 +1,5 @@
+class Admin::DashboardController < ApplicationController
+  def index
+    render inertia: { user: 1 }
+  end
+end

--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -1,0 +1,13 @@
+class Admin::ItemsController < ApplicationController
+  def index
+    render inertia: { user: 1 }
+  end
+
+  def edit
+    render inertia: { user: 1 }
+  end
+
+  def show
+    render inertia: { user: 2 }
+  end
+end

--- a/app/controllers/admin/municipalities_controller.rb
+++ b/app/controllers/admin/municipalities_controller.rb
@@ -1,0 +1,23 @@
+class Admin::MunicipalitiesController < ApplicationController
+  def index
+    municipalities_list = Municipality.all
+
+    municipalities_list.each do |m|
+      p m.as_json
+    end
+
+    render inertia: { user: 1 }
+  end
+
+  def edit
+    render inertia: { user: 1 }
+  end
+
+  def show
+    municipality = Municipality.find(params[:id])
+
+    puts "hello? " + municipality.kanji_name
+
+    render inertia: { user: 2 }
+  end
+end

--- a/app/controllers/admin/prefectures_controller.rb
+++ b/app/controllers/admin/prefectures_controller.rb
@@ -1,0 +1,17 @@
+class Admin::PrefecturesController < ApplicationController
+  def index
+    render inertia: { user: 1 }
+  end
+
+  def edit
+    render inertia: { user: 1 }
+  end
+
+  def show
+    prefecture = Prefecture.find(params[:id])
+
+    puts "hello? " + prefecture.kanji_name
+
+    render inertia: { user: 2 }
+  end
+end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,2 +1,0 @@
-class ItemsController < ApplicationController
-end

--- a/app/controllers/municipalities_controller.rb
+++ b/app/controllers/municipalities_controller.rb
@@ -1,2 +1,0 @@
-class MunicipalitiesController < ApplicationController
-end

--- a/app/controllers/prefectures_controller.rb
+++ b/app/controllers/prefectures_controller.rb
@@ -1,2 +1,0 @@
-class PrefecturesController < ApplicationController
-end

--- a/app/frontend/pages/admin/dashboard/index.tsx
+++ b/app/frontend/pages/admin/dashboard/index.tsx
@@ -1,0 +1,12 @@
+import { Head } from "@inertiajs/react";
+
+export default function AdminDashboard() {
+  return (
+    <>
+      <Head title="Inertia + Vite Ruby + React Example" />
+      <div>
+        <h1>Admin dashboard</h1>
+      </div>
+    </>
+  );
+}

--- a/app/frontend/pages/admin/items/edit.tsx
+++ b/app/frontend/pages/admin/items/edit.tsx
@@ -1,0 +1,12 @@
+import { Head } from "@inertiajs/react";
+
+export default function ItemEdit() {
+  return (
+    <>
+      <Head title="Inertia + Vite Ruby + React Example" />
+      <div>
+        <h1>Item edit page</h1>
+      </div>
+    </>
+  );
+}

--- a/app/frontend/pages/admin/items/index.tsx
+++ b/app/frontend/pages/admin/items/index.tsx
@@ -1,0 +1,12 @@
+import { Head } from "@inertiajs/react";
+
+export default function ItemsIndex() {
+  return (
+    <>
+      <Head title="Inertia + Vite Ruby + React Example" />
+      <div>
+        <h1>Items index page</h1>
+      </div>
+    </>
+  );
+}

--- a/app/frontend/pages/admin/items/show.tsx
+++ b/app/frontend/pages/admin/items/show.tsx
@@ -1,0 +1,12 @@
+import { Head } from "@inertiajs/react";
+
+export default function ItemShow() {
+  return (
+    <>
+      <Head title="Inertia + Vite Ruby + React Example" />
+      <div>
+        <h1>Item show page</h1>
+      </div>
+    </>
+  );
+}

--- a/app/frontend/pages/admin/municipalities/edit.tsx
+++ b/app/frontend/pages/admin/municipalities/edit.tsx
@@ -1,0 +1,12 @@
+import { Head } from "@inertiajs/react";
+
+export default function MunicipalityEdit() {
+  return (
+    <>
+      <Head title="Inertia + Vite Ruby + React Example" />
+      <div>
+        <h1>Municipality edit page</h1>
+      </div>
+    </>
+  );
+}

--- a/app/frontend/pages/admin/municipalities/index.tsx
+++ b/app/frontend/pages/admin/municipalities/index.tsx
@@ -1,0 +1,12 @@
+import { Head } from "@inertiajs/react";
+
+export default function MunicipalitiesIndex() {
+  return (
+    <>
+      <Head title="Inertia + Vite Ruby + React Example" />
+      <div>
+        <h1>Admin municipalities index page</h1>
+      </div>
+    </>
+  );
+}

--- a/app/frontend/pages/admin/municipalities/show.tsx
+++ b/app/frontend/pages/admin/municipalities/show.tsx
@@ -1,0 +1,12 @@
+import { Head } from "@inertiajs/react";
+
+export default function MunicipalityShow() {
+  return (
+    <>
+      <Head title="Inertia + Vite Ruby + React Example" />
+      <div>
+        <h1>Admin municipality show page</h1>
+      </div>
+    </>
+  );
+}

--- a/app/frontend/pages/admin/prefectures/edit.tsx
+++ b/app/frontend/pages/admin/prefectures/edit.tsx
@@ -1,0 +1,12 @@
+import { Head } from "@inertiajs/react";
+
+export default function PrefectureEdit() {
+  return (
+    <>
+      <Head title="Inertia + Vite Ruby + React Example" />
+      <div>
+        <h1>Prefecture edit page</h1>
+      </div>
+    </>
+  );
+}

--- a/app/frontend/pages/admin/prefectures/index.tsx
+++ b/app/frontend/pages/admin/prefectures/index.tsx
@@ -1,0 +1,12 @@
+import { Head } from "@inertiajs/react";
+
+export default function PrefecturesIndex() {
+  return (
+    <>
+      <Head title="Inertia + Vite Ruby + React Example" />
+      <div>
+        <h1>Admin prefectures index page</h1>
+      </div>
+    </>
+  );
+}

--- a/app/frontend/pages/admin/prefectures/show.tsx
+++ b/app/frontend/pages/admin/prefectures/show.tsx
@@ -1,0 +1,12 @@
+import { Head } from "@inertiajs/react";
+
+export default function PrefectureShow() {
+  return (
+    <>
+      <Head title="Inertia + Vite Ruby + React Example" />
+      <div>
+        <h1>Prefecture show page</h1>
+      </div>
+    </>
+  );
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,13 @@ Rails.application.routes.draw do
   resources :passwords, param: :token, only: [ :new ]
   inertia "/" => "Landing"
 
+  namespace "admin" do
+    resources :municipalities, :prefectures, :items
+
+    get "/", to: redirect("/admin/dashboard")
+    get "dashboard", to: "dashboard#index"
+  end
+
   namespace "gomi_guesser" do
     inertia "/" => "Landing"
     inertia "/test" => "Landing"


### PR DESCRIPTION
### What changed, and _why_?
This adds placeholder UI for an admin dashboard as well as `index` (corresponds to UI for viewing all instances of a resource), `edit` (UI for editing a single resource)  and `show` (UI for viewing a single resource) pages for `items`, `municipalities`, and `prefectures`. Also redirects a user from `/admin/` to `/admin/dashboard`.

If running the app locally, you can try viewing the created pages by visiting the following urls:
- `/admin/dashboard` (and `/admin` to see the redirect in action)
- `/admin/items` - corresponds to `/admin/items_controller.rb#index`
- `/admin/items/:id` - corresponds to `/admin/items_controller.rb#show`
- `/admin/items/:id/edit` - corresponds to `/admin/items_controller.rb#edit`

- `/admin/municipalities` - corresponds to `/admin/municipalities_controller.rb#index`
- `/admin/municipalities/:id` - corresponds to `/admin/municipalities_controller.rb#show`
- `/admin/municipalities/:id/edit` - corresponds to `/admin/municipalities_controller.rb#edit`

- `/admin/prefectures` - corresponds to `/admin/prefectures_controller.rb#index`
- `/admin/prefectures/:id` - corresponds to `/admin/prefectures_controller.rb#show`
- `/admin/prefectures/:id/edit` - corresponds to `/admin/prefectures_controller.rb#edit`


### Screenshots (if relevant)

### Any other considerations
The convention for how inertia finds the right front end page/component to render can be read about [here](https://inertia-rails.dev/guide/pages#creating-pages).

I intend to use a Ruby serialization library called [Alba](https://github.com/okuramasafumi/alba), and a library for generating TypeScript types based on the serialized Alba object called [Typelizer](https://github.com/skryukov/typelizer) to pass typed page props from Rails/Inertia to React/TypeScript. I'll likely tackle this work in an upcoming PR, after which I'll try to flesh out the actual UI for the pages I created in this PR. 