### PR TITLE
upgrade brakeman from 7.1.1 to 7.1.2 by running "bunle update brakeman"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
-    brakeman (7.1.1)
+    brakeman (7.1.2)
       racc
     builder (3.3.0)
     capybara (3.40.0)


### PR DESCRIPTION
### What changed, and _why_?
Update `brakeman` gem from 7.1.1 to 7.2.2 to fix failing github action.

### Screenshots (if relevant)

### Any other considerations
