### PR TITLE
Remove typelizer gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,8 +37,6 @@ gem "thruster", require: false
 # serialization library for Ruby https://github.com/okuramasafumi/alba
 gem "alba"
 
-# library for generating tpyescript types based on serializer objects, in this case alba
-gem "typelizer"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -337,9 +337,6 @@ GEM
     thruster (0.1.15-x86_64-linux)
     timeout (0.4.3)
     tsort (0.2.0)
-    typelizer (0.5.4)
-      benchmark
-      railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.2.0)
@@ -396,7 +393,6 @@ DEPENDENCIES
   solid_queue
   sqlite3 (>= 2.1)
   thruster
-  typelizer
   tzinfo-data
   vite_rails (~> 3.0)
   web-console


### PR DESCRIPTION
### What changed, and _why_?
I ran `bundle remove typelizer` to remove the typelizer gem as I don't plan to use it for now, but also I tried running `kamal deploy` and was getting an error:

```bash
LoadError: cannot load such file -- /usr/local/bundle/ruby/3.2.0/gems/typelizer-0.5.4/lib/typelizer/type_parser (LoadError)
```

Even if this doesn't fix the `kamal deploy` error, I don't plan to use the typelizer gem for the moment.

### Screenshots (if relevant)

### Any other considerations
