### PR TITLE
Remove typelizer references in ruby code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,8 +37,6 @@ gem "thruster", require: false
 # serialization library for Ruby https://github.com/okuramasafumi/alba
 gem "alba"
 
-# library for generating tpyescript types based on serializer objects, in this case alba
-gem "typelizer"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -337,9 +337,6 @@ GEM
     thruster (0.1.15-x86_64-linux)
     timeout (0.4.3)
     tsort (0.2.0)
-    typelizer (0.5.4)
-      benchmark
-      railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.2.0)
@@ -396,7 +393,6 @@ DEPENDENCIES
   solid_queue
   sqlite3 (>= 2.1)
   thruster
-  typelizer
   tzinfo-data
   vite_rails (~> 3.0)
   web-console


### PR DESCRIPTION
### What changed, and _why_?
See title.

### Screenshots (if relevant)

### Any other considerations
