### PR TITLE
remove typelizer references in ruby code

### DIFF
--- a/app/serializers/ApplicationResource.rb
+++ b/app/serializers/ApplicationResource.rb
@@ -1,6 +1,3 @@
 class ApplicationResource
   include Alba::Resource
-  # For Alba, we recommend using the `helper` method instead of `include`.
-  # See the documentation: https://github.com/okuramasafumi/alba/blob/main/README.md#helper
-  helper Typelizer::DSL
 end

--- a/config/initializers/typelizer.rb
+++ b/config/initializers/typelizer.rb
@@ -1,3 +1,0 @@
-Typelizer.configure do |config|
-  config.types_import_path = "@/types/serializers"
-end


### PR DESCRIPTION
### What changed, and _why_?

### Screenshots (if relevant)

### Any other considerations
