### PR TITLE
update inertiajs/react npm package and inertia_rails gem to latest ve…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,6 @@ group :test do
   gem "selenium-webdriver"
 end
 
-gem "inertia_rails", "~> 3.15"
+gem "inertia_rails", "~> 3.18"
 
 gem "vite_rails", "~> 3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
     bcrypt_pbkdf (1.1.1)
     bcrypt_pbkdf (1.1.1-arm64-darwin)
     benchmark (0.5.0)
-    bigdecimal (3.3.1)
+    bigdecimal (4.0.1)
     bindex (0.8.1)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
@@ -109,7 +109,7 @@ GEM
     drb (2.2.3)
     dry-cli (1.3.0)
     ed25519 (1.4.0)
-    erb (6.0.1)
+    erb (6.0.2)
     erubi (1.13.1)
     et-orbi (1.3.0)
       tzinfo
@@ -118,13 +118,14 @@ GEM
       raabro (~> 1.4)
     globalid (1.3.0)
       activesupport (>= 6.1)
-    i18n (1.14.7)
+    i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    inertia_rails (3.15.0)
+    inertia_rails (3.18.0)
       railties (>= 6)
     io-console (0.8.2)
-    irb (1.15.3)
+    irb (1.17.0)
       pp (>= 0.6.0)
+      prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     jbuilder (2.14.1)
@@ -145,7 +146,7 @@ GEM
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
-    loofah (2.24.1)
+    loofah (2.25.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.8.1)
@@ -156,7 +157,9 @@ GEM
     marcel (1.1.0)
     matrix (0.4.3)
     mini_mime (1.1.5)
-    minitest (5.27.0)
+    minitest (6.0.2)
+      drb (~> 2.0)
+      prism (~> 1.5)
     msgpack (1.8.0)
     mutex_m (0.3.0)
     net-imap (0.5.10)
@@ -174,11 +177,11 @@ GEM
       net-protocol
     net-ssh (7.3.0)
     nio4r (2.7.4)
-    nokogiri (1.18.10-aarch64-linux-gnu)
+    nokogiri (1.19.1-aarch64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.18.10-arm64-darwin)
+    nokogiri (1.19.1-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.10-x86_64-linux-gnu)
+    nokogiri (1.19.1-x86_64-linux-gnu)
       racc (~> 1.4)
     ostruct (0.6.3)
     parallel (1.27.0)
@@ -193,7 +196,7 @@ GEM
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
       rack
-    psych (5.3.0)
+    psych (5.3.1)
       date
       stringio
     public_suffix (6.0.2)
@@ -201,7 +204,7 @@ GEM
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (3.2.4)
+    rack (3.2.5)
     rack-proxy (0.7.7)
       rack
     rack-session (2.1.1)
@@ -229,8 +232,8 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.6.2)
-      loofah (~> 2.21)
+    rails-html-sanitizer (1.7.0)
+      loofah (~> 2.25)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     railties (8.0.3)
       actionpack (= 8.0.3)
@@ -243,7 +246,7 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.3.1)
-    rdoc (6.17.0)
+    rdoc (7.2.0)
       erb
       psych (>= 4.0.0)
       tsort
@@ -331,8 +334,8 @@ GEM
       net-sftp (>= 2.1.2)
       net-ssh (>= 2.8.0)
       ostruct
-    stringio (3.1.9)
-    thor (1.4.0)
+    stringio (3.2.0)
+    thor (1.5.0)
     thruster (0.1.15-aarch64-linux)
     thruster (0.1.15-arm64-darwin)
     thruster (0.1.15-x86_64-linux)
@@ -366,7 +369,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.7.3)
+    zeitwerk (2.7.5)
 
 PLATFORMS
   aarch64-linux
@@ -380,7 +383,7 @@ DEPENDENCIES
   brakeman
   capybara
   debug
-  inertia_rails (~> 3.15)
+  inertia_rails (~> 3.18)
   jbuilder
   kamal
   propshaft

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@inertiajs/react": "^2.2.3",
+        "@inertiajs/react": "^2.3.18",
         "@tailwindcss/forms": "^0.5.10",
         "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.1.13",
@@ -19,12 +19,12 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.2",
+        "@types/node": "^25.0.3",
         "eslint": "^9.39.2",
         "eslint-plugin-react": "^7.37.5",
         "globals": "^16.5.0",
         "jiti": "^2.6.1",
         "typescript-eslint": "^8.50.0",
-        "@types/node": "^25.0.3",
         "vite": "^7.1.7",
         "vite-plugin-ruby": "^5.1.1"
       }
@@ -918,29 +918,32 @@
       }
     },
     "node_modules/@inertiajs/core": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@inertiajs/core/-/core-2.2.3.tgz",
-      "integrity": "sha512-+aUIBGCRnRadACG5++5HBS41CvKf4z+DTnINQGjr1ToeiD6xPbXM4D+rKweSfSR+wgmL5TIdyeRM7vYJ3v57qQ==",
+      "version": "2.3.18",
+      "resolved": "https://registry.npmjs.org/@inertiajs/core/-/core-2.3.18.tgz",
+      "integrity": "sha512-StOszdE28nx9uxY4I28d7oLRGLdu/F9pRgWody2k29Qe9WqAoPHVQ5VJabTi2RTYHJXZrZZ+Wgtw3qVRZMrwOA==",
       "license": "MIT",
       "dependencies": {
         "@types/lodash-es": "^4.17.12",
-        "axios": "^1.12.2",
-        "lodash-es": "^4.17.21",
-        "qs": "^6.14.0"
+        "axios": "^1.13.5",
+        "laravel-precognition": "^1.0.2",
+        "lodash-es": "^4.17.23",
+        "qs": "^6.15.0"
       }
     },
     "node_modules/@inertiajs/react": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@inertiajs/react/-/react-2.2.3.tgz",
-      "integrity": "sha512-Jcn5diRnjSdZL/4SVIMxPPms12oFDIjMPIWsWk0PujXyFmZfRZcTLMrCKdyNE/OPJfq/UBX1eZTWIlS0ZCcThA==",
+      "version": "2.3.18",
+      "resolved": "https://registry.npmjs.org/@inertiajs/react/-/react-2.3.18.tgz",
+      "integrity": "sha512-kcoPveEDN7vyjqhyFEa9dlBjgvAsrz9k9YlrSK9PFJxRBGpCAnovmU37/a9AG2ORUP1zLw2P8y+5QfMgRdEPfw==",
       "license": "MIT",
       "dependencies": {
-        "@inertiajs/core": "2.2.3",
+        "@inertiajs/core": "2.3.18",
         "@types/lodash-es": "^4.17.12",
-        "lodash-es": "^4.17.21"
+        "laravel-precognition": "^1.0.2",
+        "lodash-es": "^4.17.23"
       },
       "peerDependencies": {
-        "react": "^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+        "react": "^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@isaacs/fs-minipass": {
@@ -1671,9 +1674,9 @@
       "license": "MIT"
     },
     "node_modules/@types/lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==",
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
       "license": "MIT"
     },
     "node_modules/@types/lodash-es": {
@@ -2236,13 +2239,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
-      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -3264,9 +3267,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -4134,6 +4137,16 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/laravel-precognition": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/laravel-precognition/-/laravel-precognition-1.0.2.tgz",
+      "integrity": "sha512-0H08JDdMWONrL/N314fvsO3FATJwGGlFKGkMF3nNmizVFJaWs17816iM+sX7Rp8d5hUjYCx6WLfsehSKfaTxjg==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.4.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -4393,9 +4406,9 @@
       }
     },
     "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -4900,9 +4913,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "vite-plugin-ruby": "^5.1.1"
   },
   "dependencies": {
-    "@inertiajs/react": "^2.2.3",
+    "@inertiajs/react": "^2.3.18",
     "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.1.13",


### PR DESCRIPTION
### What changed, and _why_?
I upgraded the `inertia_rails` gem from version `3.15.0` to version `3.18.0` and updated the `@inertiajs/react` npm package from version `2.2.3` to version `2.3.18` to be able to utilize flash messages in my rails controllers, and to be able to read those messages on the front end.

### Screenshots (if relevant)

### Any other considerations
I ran `bundle upgrade inertia_rails` which seemed to update the `Gemfile.lock` file with version `2.3.18` but did not change the `Gemfile` at all. I manually updated the `Gemfile` with version `2.3.18` afterward. I also did something similar with front end dependencies - ran `npm update @inertiajs/react` which changed `package-lock.json` but did not automatically update `package.json` with the new version. I manually wrote that version in as well. I'm not entirely sure if this was the correct or a good way to upgrade these dependencies, but it seems to work locally as I could get flash messages to surface on the front end.