### PR TITLE
Upgrade brakeman gem to version 8.0.4 to fix failing CI runs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
-    brakeman (7.1.2)
+    brakeman (8.0.4)
       racc
     builder (3.3.0)
     capybara (3.40.0)


### PR DESCRIPTION
### What changed, and _why_?
Ran `bundle update brakeman` to fix failing CI.

### Screenshots (if relevant)

### Any other considerations
This fixes the brakeman version issue, but CI still fails because the current ruby version for the project is 3.2.2 (found in the `.ruby-version` file in the root of the project) which will be End of Life'd (EOL) on 3/31/2026. I should probably update the version soon...maybe target version 4.0.2 which is the latest as of checking on 3/17/2026. 
