### PR TITLE
Implement fullstack resource routes for an Item

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -1,13 +1,85 @@
 class Admin::ItemsController < ApplicationController
   def index
-    render inertia: { user: 1 }
+    all_items = Item.order("lower(eng_name)")
+
+    items_with_paths = all_items.map do |i|
+      { **i.attributes, item_path: admin_item_path(i.id) }
+    end
+
+    render inertia: { items: items_with_paths, new_item_path: new_admin_item_path }
+  end
+
+  def new
+    render inertia: { admin_items_path: admin_items_path }
+  end
+
+  def create
+    new_item = Item.create(item_params)
+
+    if new_item.save
+      redirect_to admin_items_path, notice: "Item created successfully: #{new_item.eng_name}"
+    else
+      redirect_to new_admin_item_path, inertia: { errors: new_item.errors.full_messages }
+    end
   end
 
   def edit
-    render inertia: { user: 1 }
+    item = Item.find(params[:id])
+
+    item_path = admin_item_path(params[:id])
+
+    item_with_links = {
+      **item.attributes,
+      member_item_path: item_path
+    }
+
+    render inertia: { item: item_with_links }
+  end
+
+  def update
+    existing_item = Item.find(params[:id])
+
+    if existing_item.update(item_params)
+      redirect_to admin_item_path(existing_item.id), notice: "Item updated successfully!"
+    else
+      redirect_to edit_admin_item_path(existing_item.id), inertia: { errors: existing_item.errors.full_messages }
+    end
   end
 
   def show
-    render inertia: { user: 2 }
+    item = Item.find(params[:id])
+
+    item_with_links = {
+      **item.attributes,
+      items_index_path: admin_items_path,
+      item_edit_path: edit_admin_item_path(item.id),
+      item_path: admin_item_path(item.id)
+    }
+
+    render inertia: { item: item_with_links }
+  end
+
+  def destroy
+    item = Item.find(params[:id])
+
+    if item.destroy
+      redirect_to admin_items_path, notice: "Item deleted: #{item.eng_name}"
+    else
+      redirect_to edit_admin_item_path(item.id), inertia: { errors: existing_item.errors.full_messages }
+    end
+  end
+
+  # this should go in something like items_rules_controller.rb - relates municipalities to items
+  # allow someone can mass copy rules from one municipality to another
+  # def copy_rules(item_ids_array_or_just_items, new_municipality_id)
+  #   # make sure new_municipality_id references a row in the db
+  #   # make sure item_ids in item_ids_array also all exist? or can send all the required data in the request so don't need to look them up in db?
+  #   # don't need to copy created_at, updated_at, etc
+  # end
+
+  private
+
+  def item_params
+    params.expect(item: [ :eng_name, :kanji_name, :kana_name ])
   end
 end

--- a/app/controllers/admin/municipalities_controller.rb
+++ b/app/controllers/admin/municipalities_controller.rb
@@ -1,23 +1,18 @@
 class Admin::MunicipalitiesController < ApplicationController
   def index
-    municipalities_list = Municipality.all
+    municipalities_list = Municipality.order(:alphanumeric_eng_name).where(prefecture_id: params[:prefecture_id])
 
-    municipalities_list.each do |m|
-      p m.as_json
+    municipalities_with_path = municipalities_list.map do |m|
+      { **m.attributes, municipality_path: admin_municipality_path(m.id) }
     end
 
-    render inertia: { user: 1 }
-  end
-
-  def edit
-    render inertia: { user: 1 }
+    render inertia: { municipalities: municipalities_with_path, errors: [] }
   end
 
   def show
+    # find() raises an ActiveRecord::RecordNotFound if not found
     municipality = Municipality.find(params[:id])
 
-    puts "hello? " + municipality.kanji_name
-
-    render inertia: { user: 2 }
+    render inertia: { municipality: municipality }
   end
 end

--- a/app/controllers/admin/municipalities_controller.rb
+++ b/app/controllers/admin/municipalities_controller.rb
@@ -13,6 +13,11 @@ class Admin::MunicipalitiesController < ApplicationController
     # find() raises an ActiveRecord::RecordNotFound if not found
     municipality = Municipality.find(params[:id])
 
-    render inertia: { municipality: municipality }
+    municipality_with_links = {
+      **municipality.attributes,
+      all_prefecture_municipalities_path: admin_prefecture_municipalities_path(municipality.prefecture_id)
+    }
+
+    render inertia: { municipality: municipality_with_links }
   end
 end

--- a/app/controllers/admin/prefectures_controller.rb
+++ b/app/controllers/admin/prefectures_controller.rb
@@ -1,17 +1,51 @@
 class Admin::PrefecturesController < ApplicationController
   def index
-    render inertia: { user: 1 }
+    all_prefectures = Prefecture.order(:alphanumeric_eng_name)
+
+    prefectures_with_path = all_prefectures.map do |p|
+      { **p.attributes, prefecture_path: admin_prefecture_path(p.id) }
+    end
+
+    render inertia: { prefectures: prefectures_with_path, errors: [] }
   end
 
   def edit
-    render inertia: { user: 1 }
+    # find() raises an ActiveRecord::RecordNotFound if not found
+    prefecture = Prefecture.find(params[:id])
+
+    prefecture_with_links = {
+      **prefecture.attributes,
+      member_prefecture_path: admin_prefecture_path(prefecture.id),
+      all_prefectures_path: admin_prefectures_path
+    }
+
+    render inertia: { prefecture: prefecture_with_links, errors: [] }
+  end
+
+  def update
+    # implement later, for now just want to redirect to prefecture page
+    puts update_params
+
+    redirect_to admin_prefecture_url(params[:id]), inertia: { errors: {} }
   end
 
   def show
+    # find() raises an ActiveRecord::RecordNotFound if not found
     prefecture = Prefecture.find(params[:id])
 
-    puts "hello? " + prefecture.kanji_name
+    prefecture_with_links = {
+      **prefecture.attributes,
+      edit_prefecture_path: edit_admin_prefecture_path(prefecture.id),
+      all_prefectures_path: admin_prefectures_path,
+      view_municipalities_path: admin_prefecture_municipalities_path(prefecture.id)
+    }
 
-    render inertia: { user: 2 }
+    render inertia: { prefecture: prefecture_with_links, errors: [] }
+  end
+
+  private
+
+  def update_params
+    params.require(:prefecture).permit(:eng_name, :alphanumeric_eng_name, :kanji_name, :kana_name)
   end
 end

--- a/app/controllers/admin/prefectures_controller.rb
+++ b/app/controllers/admin/prefectures_controller.rb
@@ -9,33 +9,13 @@ class Admin::PrefecturesController < ApplicationController
     render inertia: { prefectures: prefectures_with_path, errors: [] }
   end
 
-  def edit
-    # find() raises an ActiveRecord::RecordNotFound if not found
-    prefecture = Prefecture.find(params[:id])
-
-    prefecture_with_links = {
-      **prefecture.attributes,
-      member_prefecture_path: admin_prefecture_path(prefecture.id),
-      all_prefectures_path: admin_prefectures_path
-    }
-
-    render inertia: { prefecture: prefecture_with_links, errors: [] }
-  end
-
-  def update
-    # implement later, for now just want to redirect to prefecture page
-    puts update_params
-
-    redirect_to admin_prefecture_url(params[:id]), inertia: { errors: {} }
-  end
-
   def show
     # find() raises an ActiveRecord::RecordNotFound if not found
     prefecture = Prefecture.find(params[:id])
 
     prefecture_with_links = {
       **prefecture.attributes,
-      edit_prefecture_path: edit_admin_prefecture_path(prefecture.id),
+      # edit_prefecture_path: edit_admin_prefecture_path(prefecture.id),
       all_prefectures_path: admin_prefectures_path,
       view_municipalities_path: admin_prefecture_municipalities_path(prefecture.id)
     }
@@ -44,8 +24,4 @@ class Admin::PrefecturesController < ApplicationController
   end
 
   private
-
-  def update_params
-    params.require(:prefecture).permit(:eng_name, :alphanumeric_eng_name, :kanji_name, :kana_name)
-  end
 end

--- a/app/frontend/components/Flash.tsx
+++ b/app/frontend/components/Flash.tsx
@@ -1,0 +1,49 @@
+import { usePage } from "@inertiajs/react";
+
+// might have flash values that are not simple strings, but rather an object in the shape {type: string; message: string;}
+// and want to be able to narrow it appropriately
+// function isObjFlash(
+//   value: unknown,
+// ): value is { type: string; message: string } {
+//   return (
+//     typeof value == "object" &&
+//     value !== null &&
+//     "type" in value &&
+//     typeof value.type === "string" &&
+//     "message" in value &&
+//     typeof value.message === "string"
+//   );
+// }
+
+// by default, rails/inertia has :notice and :alert flash messages
+// seems like :notice could be used for something like success messages, while :alert might be used to flash a warning or error
+export function Flash() {
+  const { flash } = usePage();
+
+  const flashEntries = Object.entries(flash);
+
+  return flashEntries.length > 0 ? (
+    <div>
+      {flashEntries.map(([k, v], idx) => {
+        if (typeof v === "string") {
+          if (k === "notice")
+            return (
+              <p key={idx} className="bg-green-400 p-4">
+                {String(v)}
+              </p>
+            );
+          if (k === "alert") {
+            return (
+              <p key={idx} className="border-red-600 p-4">
+                {String(v)}
+              </p>
+            );
+          }
+        } else {
+          // only handling string flash values for now, if handling other shapes don't return null
+          return null;
+        }
+      })}
+    </div>
+  ) : null;
+}

--- a/app/frontend/components/FormErrorsDisplay.tsx
+++ b/app/frontend/components/FormErrorsDisplay.tsx
@@ -1,0 +1,23 @@
+// disabling react/prop-types rule because I don't think it's necessary here. usePage() should always provide a props object, and
+// with the way inertia_rails is configured it should always provie an errors field in the props
+
+/* eslint react/prop-types: 0 */
+
+import { usePage } from "@inertiajs/react";
+
+export function FormErrorsDisplay() {
+  const { props } = usePage();
+
+  const errors = props.errors;
+  return (
+    <>
+      {Array.isArray(errors) && errors.length > 0 ? (
+        <div className="border-red-600 border-2 p-4 rounded-2xl bg-red-100">
+          {errors.map((err) => {
+            return <p key={err}>{err}</p>;
+          })}
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/app/frontend/entrypoints/inertia.ts
+++ b/app/frontend/entrypoints/inertia.ts
@@ -1,12 +1,13 @@
-import { createInertiaApp } from '@inertiajs/react'
-import { createElement, ReactNode } from 'react'
-import { createRoot } from 'react-dom/client'
+import { createInertiaApp } from "@inertiajs/react";
+import { createElement, ReactNode } from "react";
+import { createRoot } from "react-dom/client";
+import Layout from "@/layouts/Layout";
 
 // Temporary type definition, until @inertiajs/react provides one
 type ResolvedComponent = {
-  default: ReactNode
-  layout?: (page: ReactNode) => ReactNode
-}
+  default: ReactNode;
+  layout?: (page: ReactNode) => ReactNode;
+};
 
 createInertiaApp({
   // Set default page title
@@ -20,32 +21,37 @@ createInertiaApp({
   // progress: false,
 
   resolve: (name) => {
-    const pages = import.meta.glob<ResolvedComponent>('../pages/**/*.tsx', {
+    const pages = import.meta.glob<ResolvedComponent>("../pages/**/*.tsx", {
       eager: true,
-    })
-    const page = pages[`../pages/${name}.tsx`]
+    });
+    const page = pages[`../pages/${name}.tsx`];
     if (!page) {
-      console.error(`Missing Inertia page component: '${name}.tsx'`)
+      console.error(`Missing Inertia page component: '${name}.tsx'`);
     }
 
     // To use a default layout, import the Layout component
     // and use the following line.
     // see https://inertia-rails.dev/guide/pages#default-layouts
-    //
-    // page.default.layout ||= (page) => createElement(Layout, null, page)
 
-    return page
+    if (page.default) {
+      // 1/10/2025 - can't figure out how to get around this type error, so ignoring for now
+      // @ts-expect-error - not sure how to resolve error. page.default is a ReactNode and we're trying to access the "layout" property
+      // which is not included in the definition for ReactNode
+      page.default.layout ||= (page) => createElement(Layout, null, page);
+    }
+
+    return page;
   },
 
   setup({ el, App, props }) {
     if (el) {
-      createRoot(el).render(createElement(App, props))
+      createRoot(el).render(createElement(App, props));
     } else {
       console.error(
-        'Missing root element.\n\n' +
-          'If you see this error, it probably means you load Inertia.js on non-Inertia pages.\n' +
-          'Consider moving <%= vite_typescript_tag "inertia" %> to the Inertia-specific layout instead.',
-      )
+        "Missing root element.\n\n" +
+          "If you see this error, it probably means you load Inertia.js on non-Inertia pages.\n" +
+          'Consider moving <%= vite_typescript_tag "inertia" %> to the Inertia-specific layout instead.'
+      );
     }
   },
-})
+});

--- a/app/frontend/layouts/Layout.tsx
+++ b/app/frontend/layouts/Layout.tsx
@@ -1,11 +1,14 @@
+import { Head } from "@inertiajs/react";
+
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <>
+      <Head title="Gomi guessing" />
       <header className="flex gap-1 justify-between flex-wrap items-center bg-amber-500 p-1.5">
         <a>Gomi home</a>
         <nav>Nav</nav>
       </header>
-      <main className="bg-blue-500 mt-0 mx-auto max-w-2xl">{children}</main>
+      <main className="mt-0 mx-auto max-w-2xl">{children}</main>
     </>
   );
 }

--- a/app/frontend/layouts/Layout.tsx
+++ b/app/frontend/layouts/Layout.tsx
@@ -1,5 +1,8 @@
 import { Head } from "@inertiajs/react";
 
+import { Flash } from "@/components/Flash";
+import { FormErrorsDisplay } from "@/components/FormErrorsDisplay";
+
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <>
@@ -8,7 +11,11 @@ export default function Layout({ children }: { children: React.ReactNode }) {
         <a>Gomi home</a>
         <nav>Nav</nav>
       </header>
-      <main className="mt-0 mx-auto max-w-2xl">{children}</main>
+      <main className="mt-0 mx-auto max-w-2xl">
+        <Flash />
+        <FormErrorsDisplay />
+        {children}
+      </main>
     </>
   );
 }

--- a/app/frontend/layouts/Layout.tsx
+++ b/app/frontend/layouts/Layout.tsx
@@ -1,0 +1,11 @@
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <header className="flex gap-1 justify-between flex-wrap items-center bg-amber-500 p-1.5">
+        <a>Gomi home</a>
+        <nav>Nav</nav>
+      </header>
+      <main className="bg-blue-500 mt-0 mx-auto max-w-2xl">{children}</main>
+    </>
+  );
+}

--- a/app/frontend/pages/Landing.tsx
+++ b/app/frontend/pages/Landing.tsx
@@ -3,7 +3,7 @@ import { Head } from "@inertiajs/react";
 export default function InertiaExample() {
   return (
     <>
-      <Head title="Inertia + Vite Ruby + React Example" />
+      <Head title="Gomi guessing" />
       <div>
         <h1>Landing page</h1>
       </div>

--- a/app/frontend/pages/Landing.tsx
+++ b/app/frontend/pages/Landing.tsx
@@ -1,9 +1,6 @@
-import { Head } from "@inertiajs/react";
-
 export default function InertiaExample() {
   return (
     <>
-      <Head title="Gomi guessing" />
       <div>
         <h1>Landing page</h1>
       </div>

--- a/app/frontend/pages/admin/dashboard/index.tsx
+++ b/app/frontend/pages/admin/dashboard/index.tsx
@@ -3,7 +3,7 @@ import { Head } from "@inertiajs/react";
 export default function AdminDashboard() {
   return (
     <>
-      <Head title="Inertia + Vite Ruby + React Example" />
+      <Head title="Gomi guessing" />
       <div>
         <h1>Admin dashboard</h1>
       </div>

--- a/app/frontend/pages/admin/dashboard/index.tsx
+++ b/app/frontend/pages/admin/dashboard/index.tsx
@@ -1,9 +1,6 @@
-import { Head } from "@inertiajs/react";
-
 export default function AdminDashboard() {
   return (
     <>
-      <Head title="Gomi guessing" />
       <div>
         <h1>Admin dashboard</h1>
       </div>

--- a/app/frontend/pages/admin/items/edit.tsx
+++ b/app/frontend/pages/admin/items/edit.tsx
@@ -1,9 +1,6 @@
-import { Head } from "@inertiajs/react";
-
 export default function ItemEdit() {
   return (
     <>
-      <Head title="Gomi guessing" />
       <div>
         <h1>Item edit page</h1>
       </div>

--- a/app/frontend/pages/admin/items/edit.tsx
+++ b/app/frontend/pages/admin/items/edit.tsx
@@ -3,7 +3,7 @@ import { Head } from "@inertiajs/react";
 export default function ItemEdit() {
   return (
     <>
-      <Head title="Inertia + Vite Ruby + React Example" />
+      <Head title="Gomi guessing" />
       <div>
         <h1>Item edit page</h1>
       </div>

--- a/app/frontend/pages/admin/items/edit.tsx
+++ b/app/frontend/pages/admin/items/edit.tsx
@@ -1,9 +1,63 @@
-export default function ItemEdit() {
+import { Form, Link } from "@inertiajs/react";
+
+import type { ItemBase, InertiaResponse } from "@/types/api";
+
+interface ItemWithPath extends ItemBase {
+  member_item_path: string;
+}
+
+interface ItemProps extends InertiaResponse {
+  item: ItemWithPath;
+}
+
+export default function ItemEdit({ item }: ItemProps) {
   return (
     <>
-      <div>
-        <h1>Item edit page</h1>
+      <div className="flex flex-col gap-2">
+        <div>
+          <p>
+            <Link href={item.member_item_path}>Back to items page</Link>
+          </p>
+          <p>Editing item - {item.eng_name}</p>
+        </div>
+        <Form action={`/admin/items/${item.id}`} method="put">
+          <div className="flex flex-col">
+            <label className="flex flex-col">
+              English Name:
+              <input name="eng_name" type="text" defaultValue={item.eng_name} />
+            </label>
+            <label className="flex flex-col">
+              Kanji name:
+              <input
+                name="kanji_name"
+                type="text"
+                defaultValue={item.kanji_name}
+              />
+            </label>
+            <label className="flex flex-col">
+              Kana name:
+              <input
+                name="kana_name"
+                type="text"
+                defaultValue={item.kana_name}
+              />
+            </label>
+          </div>
+          <div>
+            <button type="submit">Submit</button>
+          </div>
+        </Form>
       </div>
     </>
   );
 }
+
+// export default function ItemEdit({ item }: ItemProps) {
+//   return (
+//     <>
+//       <div>
+//         <h1>Item edit page</h1>
+//       </div>
+//     </>
+//   );
+// }

--- a/app/frontend/pages/admin/items/index.tsx
+++ b/app/frontend/pages/admin/items/index.tsx
@@ -1,9 +1,6 @@
-import { Head } from "@inertiajs/react";
-
 export default function ItemsIndex() {
   return (
     <>
-      <Head title="Gomi guessing" />
       <div>
         <h1>Items index page</h1>
       </div>

--- a/app/frontend/pages/admin/items/index.tsx
+++ b/app/frontend/pages/admin/items/index.tsx
@@ -1,8 +1,36 @@
-export default function ItemsIndex() {
+import { Link } from "@inertiajs/react";
+
+import type { ItemBase, InertiaResponse } from "@/types/api";
+
+interface ItemWithPath extends ItemBase {
+  item_path: string;
+}
+interface ItemsProps extends InertiaResponse {
+  items: Array<ItemWithPath>;
+  new_item_path: string;
+}
+
+export default function ItemsIndex({ items, new_item_path }: ItemsProps) {
   return (
     <>
       <div>
-        <h1>Items index page</h1>
+        <Link href={new_item_path}>Create new item</Link>
+        <h1>Displaying all items:</h1>
+        <ul>
+          {items.length > 0 ? (
+            items.map((item) => {
+              return (
+                <li key={item.id}>
+                  <Link href={item.item_path}>{item.eng_name}</Link>
+                </li>
+              );
+            })
+          ) : (
+            <li>
+              <p>No items to display</p>
+            </li>
+          )}
+        </ul>
       </div>
     </>
   );

--- a/app/frontend/pages/admin/items/index.tsx
+++ b/app/frontend/pages/admin/items/index.tsx
@@ -3,7 +3,7 @@ import { Head } from "@inertiajs/react";
 export default function ItemsIndex() {
   return (
     <>
-      <Head title="Inertia + Vite Ruby + React Example" />
+      <Head title="Gomi guessing" />
       <div>
         <h1>Items index page</h1>
       </div>

--- a/app/frontend/pages/admin/items/new.tsx
+++ b/app/frontend/pages/admin/items/new.tsx
@@ -1,0 +1,41 @@
+import { Form, Link } from "@inertiajs/react";
+
+import type { InertiaResponse } from "@/types/api";
+
+interface ItemProps extends InertiaResponse {
+  admin_items_path: string;
+}
+
+// not currently rendering edit route, but have component built out
+export default function ItemNew({ admin_items_path }: ItemProps) {
+  return (
+    <>
+      <div className="flex flex-col gap-2">
+        <div>
+          <p>
+            <Link href={admin_items_path}>Back to all items</Link>
+          </p>
+        </div>
+        <Form action={admin_items_path} method="post">
+          <div className="flex flex-col">
+            <label className="flex flex-col">
+              English Name:
+              <input name="item[eng_name]" type="text" />
+            </label>
+            <label className="flex flex-col">
+              Kanji name:
+              <input name="item[kanji_name]" type="text" />
+            </label>
+            <label className="flex flex-col">
+              Kana name:
+              <input name="item[kana_name]" type="text" />
+            </label>
+          </div>
+          <div>
+            <button type="submit">Submit</button>
+          </div>
+        </Form>
+      </div>
+    </>
+  );
+}

--- a/app/frontend/pages/admin/items/show.tsx
+++ b/app/frontend/pages/admin/items/show.tsx
@@ -1,9 +1,6 @@
-import { Head } from "@inertiajs/react";
-
 export default function ItemShow() {
   return (
     <>
-      <Head title="Gomi guessing" />
       <div>
         <h1>Item show page</h1>
       </div>

--- a/app/frontend/pages/admin/items/show.tsx
+++ b/app/frontend/pages/admin/items/show.tsx
@@ -1,8 +1,69 @@
-export default function ItemShow() {
+import { Link } from "@inertiajs/react";
+import { useState } from "react";
+import type { ReactNode } from "react";
+
+import type { ItemBase, InertiaResponse } from "@/types/api";
+
+interface ItemWithPath extends ItemBase {
+  items_index_path: string;
+  item_edit_path: string;
+  item_path: string;
+}
+
+interface ItemProps extends InertiaResponse {
+  item: ItemWithPath;
+}
+
+function DeleteButtonLink({
+  href,
+  children,
+}: {
+  href: string;
+  children: ReactNode;
+}) {
+  return (
+    <Link
+      className="p-2 bg-red-500 rounded-xs sm:flex-1 md:flex-[0_1_100px]"
+      href={href}
+      method="delete"
+    >
+      {children}
+    </Link>
+  );
+}
+
+export default function ItemShow({ item }: ItemProps) {
+  const [showDelete, setShowDelete] = useState(false);
+
   return (
     <>
       <div>
-        <h1>Item show page</h1>
+        <Link href={item.items_index_path}>Back to all items</Link>
+        <p>English name: {item.eng_name}</p>
+        <p>Kanji name: {item.kanji_name ?? "N/A"}</p>
+        <p>Kana name: {item.kana_name ?? "N/A"}</p>
+        <div className="flex">
+          <Link href={item.item_edit_path}>Edit</Link>
+        </div>
+        <div className="">
+          <button onClick={() => setShowDelete(true)}>Delete</button>
+          {showDelete ? (
+            <div className="flex flex-col md:flex-row gap-2 md:gap-4">
+              <DeleteButtonLink href={item.item_path}>Confirm</DeleteButtonLink>
+              {/* 
+                break out cancel button into a Button component later?
+                could use methods in this article - https://typeofnan.dev/conditional-component-props-react/
+                for handling different types of props for different types of buttons
+              */}
+              <button
+                className="p-2 bg-gray-200 rounded-xs sm:flex-1 md:flex-[0_1_100px]"
+                onClick={() => setShowDelete(false)}
+              >
+                Cancel
+              </button>
+            </div>
+          ) : null}
+        </div>
       </div>
     </>
   );

--- a/app/frontend/pages/admin/items/show.tsx
+++ b/app/frontend/pages/admin/items/show.tsx
@@ -3,7 +3,7 @@ import { Head } from "@inertiajs/react";
 export default function ItemShow() {
   return (
     <>
-      <Head title="Inertia + Vite Ruby + React Example" />
+      <Head title="Gomi guessing" />
       <div>
         <h1>Item show page</h1>
       </div>

--- a/app/frontend/pages/admin/municipalities/edit.tsx
+++ b/app/frontend/pages/admin/municipalities/edit.tsx
@@ -3,7 +3,7 @@ import { Head } from "@inertiajs/react";
 export default function MunicipalityEdit() {
   return (
     <>
-      <Head title="Inertia + Vite Ruby + React Example" />
+      <Head title="Gomi guessing" />
       <div>
         <h1>Municipality edit page</h1>
       </div>

--- a/app/frontend/pages/admin/municipalities/edit.tsx
+++ b/app/frontend/pages/admin/municipalities/edit.tsx
@@ -1,9 +1,6 @@
-import { Head } from "@inertiajs/react";
-
 export default function MunicipalityEdit() {
   return (
     <>
-      <Head title="Gomi guessing" />
       <div>
         <h1>Municipality edit page</h1>
       </div>

--- a/app/frontend/pages/admin/municipalities/edit.tsx
+++ b/app/frontend/pages/admin/municipalities/edit.tsx
@@ -1,9 +1,0 @@
-export default function MunicipalityEdit() {
-  return (
-    <>
-      <div>
-        <h1>Municipality edit page</h1>
-      </div>
-    </>
-  );
-}

--- a/app/frontend/pages/admin/municipalities/index.tsx
+++ b/app/frontend/pages/admin/municipalities/index.tsx
@@ -3,7 +3,7 @@ import { Head } from "@inertiajs/react";
 export default function MunicipalitiesIndex() {
   return (
     <>
-      <Head title="Inertia + Vite Ruby + React Example" />
+      <Head title="Gomi guessing" />
       <div>
         <h1>Admin municipalities index page</h1>
       </div>

--- a/app/frontend/pages/admin/municipalities/index.tsx
+++ b/app/frontend/pages/admin/municipalities/index.tsx
@@ -1,9 +1,6 @@
-import { Head } from "@inertiajs/react";
-
 export default function MunicipalitiesIndex() {
   return (
     <>
-      <Head title="Gomi guessing" />
       <div>
         <h1>Admin municipalities index page</h1>
       </div>

--- a/app/frontend/pages/admin/municipalities/index.tsx
+++ b/app/frontend/pages/admin/municipalities/index.tsx
@@ -1,8 +1,53 @@
-export default function MunicipalitiesIndex() {
+import { Link } from "@inertiajs/react";
+
+import type { MunicipalityBase, InertiaResponse } from "@/types/api";
+
+interface MunicipalityWithPath extends MunicipalityBase {
+  municipality_path: string;
+}
+
+interface MunicipalityListData extends InertiaResponse {
+  municipalities: Array<MunicipalityWithPath>;
+}
+
+export default function MunicipalitiesIndex({
+  municipalities,
+}: MunicipalityListData) {
   return (
     <>
       <div>
-        <h1>Admin municipalities index page</h1>
+        {municipalities.length ? (
+          <table className="w-full">
+            <thead>
+              <tr>
+                <th className="border-b border-gray-200 p-4 pt-0 pb-3 pl-8 text-left font-medium">
+                  English Name
+                </th>
+                <th className="border-b border-gray-200 p-4 pt-0 pb-3 text-left font-medium">
+                  Kanji Name
+                </th>
+                <th className="border-b border-gray-200 p-4 pt-0 pr-8 pb-3 text-left font-medium">
+                  Kana Reading
+                </th>
+              </tr>
+              {municipalities.map((m) => {
+                return (
+                  <tr key={m.eng_name}>
+                    <td className="border-b border-gray-100 p-4 pl-8 dark:border-gray-700">
+                      <Link href={m.municipality_path}>{m.eng_name}</Link>
+                    </td>
+                    <td className="border-b border-gray-100 p-4 dark:border-gray-700">
+                      <Link href={m.municipality_path}>{m.kanji_name}</Link>
+                    </td>
+                    <td className="border-b border-gray-100 p-4 pr-8 dark:border-gray-700">
+                      {m.kana_name}
+                    </td>
+                  </tr>
+                );
+              })}
+            </thead>
+          </table>
+        ) : null}
       </div>
     </>
   );

--- a/app/frontend/pages/admin/municipalities/show.tsx
+++ b/app/frontend/pages/admin/municipalities/show.tsx
@@ -1,8 +1,33 @@
-export default function MunicipalityShow() {
+import { Link } from "@inertiajs/react";
+
+import type { MunicipalityBase, InertiaResponse } from "@/types/api";
+
+interface MunicipalityWithPath extends MunicipalityBase {
+  all_prefecture_municipalities_path: string;
+  parent_prefecture_path: string;
+}
+
+interface MunicipalityProps extends InertiaResponse {
+  municipality: MunicipalityWithPath;
+}
+
+export default function MunicipalityShow({ municipality }: MunicipalityProps) {
   return (
     <>
-      <div>
-        <h1>Admin municipality show page</h1>
+      <div className="flex flex-col gap-2">
+        <div>
+          <p>
+            <Link href={municipality.all_prefecture_municipalities_path}>
+              Back to municipalities
+            </Link>
+          </p>
+        </div>
+        <div>
+          <p>{municipality.eng_name}</p>
+          <p>{municipality.kanji_name}</p>
+          <p>{municipality.kana_name}</p>
+          <p>{municipality.municipality_type}</p>
+        </div>
       </div>
     </>
   );

--- a/app/frontend/pages/admin/municipalities/show.tsx
+++ b/app/frontend/pages/admin/municipalities/show.tsx
@@ -1,9 +1,6 @@
-import { Head } from "@inertiajs/react";
-
 export default function MunicipalityShow() {
   return (
     <>
-      <Head title="Gomi guessing" />
       <div>
         <h1>Admin municipality show page</h1>
       </div>

--- a/app/frontend/pages/admin/municipalities/show.tsx
+++ b/app/frontend/pages/admin/municipalities/show.tsx
@@ -3,7 +3,7 @@ import { Head } from "@inertiajs/react";
 export default function MunicipalityShow() {
   return (
     <>
-      <Head title="Inertia + Vite Ruby + React Example" />
+      <Head title="Gomi guessing" />
       <div>
         <h1>Admin municipality show page</h1>
       </div>

--- a/app/frontend/pages/admin/prefectures/edit.tsx
+++ b/app/frontend/pages/admin/prefectures/edit.tsx
@@ -1,8 +1,66 @@
-export default function PrefectureEdit() {
+import { Form, Link } from "@inertiajs/react";
+
+import type { PrefectureBase, InertiaResponse } from "@/types/api";
+
+interface PrefectureWithPath extends PrefectureBase {
+  member_prefecture_path: string;
+}
+
+interface PrefectureProps extends InertiaResponse {
+  prefecture: PrefectureWithPath;
+}
+
+export default function PrefectureEdit({ prefecture }: PrefectureProps) {
   return (
     <>
-      <div>
-        <h1>Prefecture edit page</h1>
+      <div className="flex flex-col gap-2">
+        <div>
+          <p>
+            <Link href={prefecture.member_prefecture_path}>
+              Back to prefecture page
+            </Link>
+          </p>
+          <p>Editing {prefecture.eng_name} prefecture</p>
+        </div>
+        <Form action={`/admin/prefectures/${prefecture.id}`} method="put">
+          <div className="flex flex-col">
+            <label className="flex flex-col">
+              English Name:
+              <input
+                name="eng_name"
+                type="text"
+                defaultValue={prefecture.eng_name}
+              />
+            </label>
+            <label className="flex flex-col">
+              Alphanumeric English name (for sorting):
+              <input
+                name="alphanumeric_eng_name"
+                type="text"
+                defaultValue={prefecture.alphanumeric_eng_name}
+              />
+            </label>
+            <label className="flex flex-col">
+              Kanji name:
+              <input
+                name="kanji_name"
+                type="text"
+                defaultValue={prefecture.kanji_name}
+              />
+            </label>
+            <label className="flex flex-col">
+              Kana name:
+              <input
+                name="kana_name"
+                type="text"
+                defaultValue={prefecture.kana_name}
+              />
+            </label>
+          </div>
+          <div>
+            <button type="submit">Submit</button>
+          </div>
+        </Form>
       </div>
     </>
   );

--- a/app/frontend/pages/admin/prefectures/edit.tsx
+++ b/app/frontend/pages/admin/prefectures/edit.tsx
@@ -3,7 +3,7 @@ import { Head } from "@inertiajs/react";
 export default function PrefectureEdit() {
   return (
     <>
-      <Head title="Inertia + Vite Ruby + React Example" />
+      <Head title="Gomi guessing" />
       <div>
         <h1>Prefecture edit page</h1>
       </div>

--- a/app/frontend/pages/admin/prefectures/edit.tsx
+++ b/app/frontend/pages/admin/prefectures/edit.tsx
@@ -1,9 +1,6 @@
-import { Head } from "@inertiajs/react";
-
 export default function PrefectureEdit() {
   return (
     <>
-      <Head title="Gomi guessing" />
       <div>
         <h1>Prefecture edit page</h1>
       </div>

--- a/app/frontend/pages/admin/prefectures/edit.tsx
+++ b/app/frontend/pages/admin/prefectures/edit.tsx
@@ -10,6 +10,7 @@ interface PrefectureProps extends InertiaResponse {
   prefecture: PrefectureWithPath;
 }
 
+// not currently rendering edit route, but have component built out
 export default function PrefectureEdit({ prefecture }: PrefectureProps) {
   return (
     <>

--- a/app/frontend/pages/admin/prefectures/index.tsx
+++ b/app/frontend/pages/admin/prefectures/index.tsx
@@ -1,12 +1,74 @@
-import { Head } from "@inertiajs/react";
+import { Link } from "@inertiajs/react";
 
-export default function PrefecturesIndex() {
+import type { PrefectureBase, InertiaResponse } from "@/types/api";
+
+interface PrefectureWithPath extends PrefectureBase {
+  prefecture_path: string;
+}
+
+interface PrefectureListData extends InertiaResponse {
+  prefectures: Array<PrefectureWithPath>;
+}
+
+export default function PrefecturesIndex({
+  prefectures,
+  errors,
+}: PrefectureListData) {
   return (
     <>
-      <Head title="Gomi guessing" />
       <div>
-        <h1>Admin prefectures index page</h1>
+        <ErrorsContainer errors={errors} />
+        {prefectures.length ? (
+          <table className="w-full">
+            <thead>
+              <tr>
+                <th className="border-b border-gray-200 p-4 pt-0 pb-3 pl-8 text-left font-medium">
+                  English Name
+                </th>
+                <th className="border-b border-gray-200 p-4 pt-0 pb-3 text-left font-medium">
+                  Kanji Name
+                </th>
+                <th className="border-b border-gray-200 p-4 pt-0 pr-8 pb-3 text-left font-medium">
+                  Kana Reading
+                </th>
+              </tr>
+              {prefectures.map((p) => {
+                return (
+                  <tr key={p.eng_name}>
+                    <td className="border-b border-gray-100 p-4 pl-8 dark:border-gray-700">
+                      <Link href={p.prefecture_path}>{p.eng_name}</Link>
+                    </td>
+                    <td className="border-b border-gray-100 p-4 dark:border-gray-700">
+                      <Link href={p.prefecture_path}>{p.kanji_name}</Link>
+                    </td>
+                    <td className="border-b border-gray-100 p-4 pr-8 dark:border-gray-700">
+                      {p.kana_name}
+                    </td>
+                  </tr>
+                );
+              })}
+            </thead>
+          </table>
+        ) : (
+          <div>No prefecture data</div>
+        )}
       </div>
     </>
   );
+}
+
+function ErrorsContainer({ errors }: { errors: Array<string> }) {
+  return errors.length > 0 ? (
+    <div>
+      <ul>
+        {errors.map((e) => {
+          return (
+            <li key={e}>
+              <p>{e}</p>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  ) : null;
 }

--- a/app/frontend/pages/admin/prefectures/index.tsx
+++ b/app/frontend/pages/admin/prefectures/index.tsx
@@ -3,7 +3,7 @@ import { Head } from "@inertiajs/react";
 export default function PrefecturesIndex() {
   return (
     <>
-      <Head title="Inertia + Vite Ruby + React Example" />
+      <Head title="Gomi guessing" />
       <div>
         <h1>Admin prefectures index page</h1>
       </div>

--- a/app/frontend/pages/admin/prefectures/show.tsx
+++ b/app/frontend/pages/admin/prefectures/show.tsx
@@ -1,8 +1,42 @@
-export default function PrefectureShow() {
+import { Link } from "@inertiajs/react";
+
+import type { PrefectureBase, InertiaResponse } from "@/types/api";
+
+interface PrefectureWithPath extends PrefectureBase {
+  edit_prefecture_path: string;
+  all_prefectures_path: string;
+  view_municipalities_path: string;
+}
+
+interface PrefectureProps extends InertiaResponse {
+  prefecture: PrefectureWithPath;
+}
+
+export default function PrefectureShow({ prefecture }: PrefectureProps) {
+  console.log(prefecture);
   return (
     <>
-      <div>
-        <h1>Prefecture show page</h1>
+      <div className="flex flex-col gap-2">
+        <div>
+          <p>
+            <Link href={prefecture.all_prefectures_path}>
+              Back to prefectures list
+            </Link>
+          </p>
+          <p>
+            <Link href={prefecture.view_municipalities_path}>
+              View municipalities
+            </Link>
+          </p>
+        </div>
+        <div>
+          <p>{prefecture.eng_name}</p>
+          <p>{prefecture.kanji_name}</p>
+          <p>{prefecture.kana_name}</p>
+        </div>
+        <p>
+          <Link href={prefecture.edit_prefecture_path}>Edit</Link>
+        </p>
       </div>
     </>
   );

--- a/app/frontend/pages/admin/prefectures/show.tsx
+++ b/app/frontend/pages/admin/prefectures/show.tsx
@@ -3,7 +3,6 @@ import { Link } from "@inertiajs/react";
 import type { PrefectureBase, InertiaResponse } from "@/types/api";
 
 interface PrefectureWithPath extends PrefectureBase {
-  edit_prefecture_path: string;
   all_prefectures_path: string;
   view_municipalities_path: string;
 }
@@ -34,9 +33,6 @@ export default function PrefectureShow({ prefecture }: PrefectureProps) {
           <p>{prefecture.kanji_name}</p>
           <p>{prefecture.kana_name}</p>
         </div>
-        <p>
-          <Link href={prefecture.edit_prefecture_path}>Edit</Link>
-        </p>
       </div>
     </>
   );

--- a/app/frontend/pages/admin/prefectures/show.tsx
+++ b/app/frontend/pages/admin/prefectures/show.tsx
@@ -3,7 +3,7 @@ import { Head } from "@inertiajs/react";
 export default function PrefectureShow() {
   return (
     <>
-      <Head title="Inertia + Vite Ruby + React Example" />
+      <Head title="Gomi guessing" />
       <div>
         <h1>Prefecture show page</h1>
       </div>

--- a/app/frontend/pages/admin/prefectures/show.tsx
+++ b/app/frontend/pages/admin/prefectures/show.tsx
@@ -1,9 +1,6 @@
-import { Head } from "@inertiajs/react";
-
 export default function PrefectureShow() {
   return (
     <>
-      <Head title="Gomi guessing" />
       <div>
         <h1>Prefecture show page</h1>
       </div>

--- a/app/frontend/pages/admin/prefectures/show.tsx
+++ b/app/frontend/pages/admin/prefectures/show.tsx
@@ -12,7 +12,6 @@ interface PrefectureProps extends InertiaResponse {
 }
 
 export default function PrefectureShow({ prefecture }: PrefectureProps) {
-  console.log(prefecture);
   return (
     <>
       <div className="flex flex-col gap-2">

--- a/app/frontend/types/api/index.ts
+++ b/app/frontend/types/api/index.ts
@@ -1,8 +1,33 @@
-// from how I understand it, the files in the "serializers" directory might have circular dependencies
-// but they're only typescript types so potentially doesn't have runtime implications?
+export interface MunicipalityBase {
+  id: number;
+  municipality_type: string;
+  prefecture_id: number;
+  eng_name: string;
+  alphanumeric_eng_name: string;
+  info_url?: string;
+  kana_name: string;
+  kanji_name: string;
+  created_at: string;
+  updated_at: string;
+}
 
-// 12/22/2025 - in /types/serializers/index.ts the file imports types from other files in the directory and re-exports them, but some
-// of those types import other types from the index.ts file itself
-// for example as of 12/22/2025 the index file imports types from /types/serializers/Municipality.ts and /types/serializers/Prefecture.ts
-// the Prefecture.ts file imports the type for Municipality from the index.ts file, forming what I believe is a circular reference
-export * from "@/types/serializers";
+export interface PrefectureBase {
+  id: number;
+  eng_name: string;
+  alphanumeric_eng_name: string;
+  kana_name: string;
+  kanji_name: string;
+  created_at: string;
+  updated_at: string;
+}
+
+// looking at reddit comments from below for api response and http error shapes
+// https://www.reddit.com/r/typescript/comments/xospwb/are_there_ts_community_conventions_for_api/
+export interface HttpError {
+  code: string;
+  message: string;
+}
+
+export interface InertiaResponse {
+  errors: Array<string>;
+}

--- a/app/frontend/types/api/index.ts
+++ b/app/frontend/types/api/index.ts
@@ -21,6 +21,13 @@ export interface PrefectureBase {
   updated_at: string;
 }
 
+export interface ItemBase {
+  id: number;
+  eng_name: string;
+  kana_name?: string;
+  kanji_name?: string;
+}
+
 // looking at reddit comments from below for api response and http error shapes
 // https://www.reddit.com/r/typescript/comments/xospwb/are_there_ts_community_conventions_for_api/
 export interface HttpError {

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,3 +1,3 @@
 class Item < ApplicationRecord
-  validates :eng_name, presence: true, uniqueness: true
+  validates :eng_name, presence: true, uniqueness: { case_sensitive: false }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,16 @@ Rails.application.routes.draw do
   inertia "/" => "Landing"
 
   namespace "admin" do
-    resources :municipalities, :prefectures, :items
+    resources :items
+    resources :prefectures do
+      # https://guides.rubyonrails.org/routing.html#shallow-nesting
+      # per rails routing guide linked above, indicating "shallow: true"
+      # is like having municipality [:index, :new, :create] routes nested under prefectures
+      # e.g. /admin/prefectures/13/municipalities/ for the :index route
+      # and having municipality [:show, :edit, :update, :destroy] routes unnested
+      # e.g. /admin/municipalities/1 for the :show route
+      resources :municipalities, shallow: true
+    end
 
     get "/", to: redirect("/admin/dashboard")
     get "dashboard", to: "dashboard#index"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,14 +8,14 @@ Rails.application.routes.draw do
 
   namespace "admin" do
     resources :items
-    resources :prefectures do
+    resources :prefectures, only: [ :index, :show ] do
       # https://guides.rubyonrails.org/routing.html#shallow-nesting
       # per rails routing guide linked above, indicating "shallow: true"
       # is like having municipality [:index, :new, :create] routes nested under prefectures
       # e.g. /admin/prefectures/13/municipalities/ for the :index route
       # and having municipality [:show, :edit, :update, :destroy] routes unnested
       # e.g. /admin/municipalities/1 for the :show route
-      resources :municipalities, shallow: true
+      resources :municipalities, only: [ :index, :show ], shallow: true
     end
 
     get "/", to: redirect("/admin/dashboard")

--- a/db/migrate/20260319033856_add_case_insensitive_unique_index_to_item_eng_name.rb
+++ b/db/migrate/20260319033856_add_case_insensitive_unique_index_to_item_eng_name.rb
@@ -1,0 +1,6 @@
+class AddCaseInsensitiveUniqueIndexToItemEngName < ActiveRecord::Migration[8.0]
+  def change
+    remove_index :items, column: :eng_name
+    add_index :items, 'lower(eng_name)', unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_01_27_043716) do
+ActiveRecord::Schema[8.0].define(version: 2026_03_19_033856) do
   create_table "item_categories", force: :cascade do |t|
     t.string "name", null: false
     t.string "kanji_name", null: false
@@ -26,7 +26,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_01_27_043716) do
     t.string "kanji_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["eng_name"], name: "index_items_on_eng_name", unique: true
+    t.index "lower(eng_name)", name: "index_items_on_lower_eng_name", unique: true
   end
 
   create_table "municipalities", force: :cascade do |t|


### PR DESCRIPTION
### What changed, and _why_?
Adds full CRUD functionality for an `Item` resource. Some things to point out:
- this change includes a migration that updates the `Item` model and `items` database table to have a case-insensitive unique index on the `eng_name` field, where before it was case-sensitive i.e. before two records like `plastic bottle` and `Plastic bottle` would not cause a uniqueness constraint violation, but after the migration it would violate it.

### Screenshots (if relevant)

### Any other considerations
I did a little styling for some buttons here, but realistically need a lot more to be done.

For some of the controller methods, we're sending down links generated by Rails' route helpers in the page props. There isn't a particular abstraction for which links are being sent down at the moment, but I feel like it might make more sense to send all possible routes that can be generated by the route helpers instead of just the ones required for the page because it was a little confusing keeping track of which links are needed per page. In some cases there would be routes that don't make sense to include, such as `/admin/items/$item_id` when we're on an index page, in which case that can just be null probably.