### PR TITLE
Implement admin login page and functionality

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,5 +1,8 @@
 class Admin::DashboardController < ApplicationController
   def index
-    render inertia: { user: 1 }
+    prefectures_path = admin_prefectures_path
+    items_path = admin_items_path
+
+    render inertia: { prefectures_path: prefectures_path, items_path: items_path }
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,17 @@ class ApplicationController < ActionController::Base
   include Authentication
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+
+  inertia_share auth: -> {
+    if user_session = authenticated?
+      {
+        user: {
+          user_id: user_session.user.id,
+          email: user_session.user.email_address,
+          role: user_session.user.role,
+          username: user_session.user.username
+        }
+      }
+    end
+  }
 end

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -18,8 +18,7 @@ module Authentication
     end
 
     def require_authentication
-      false # by returning false, intend to say I don't want to require auth on routes yet
-      # resume_session || request_authentication
+      resume_session || request_authentication
     end
 
     def resume_session

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,0 +1,6 @@
+class HomeController < ApplicationController
+  allow_unauthenticated_access only: %i[ index ]
+  def index
+    render inertia: {}
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,7 +3,17 @@ class SessionsController < ApplicationController
   rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to new_session_url, alert: "Try again later." }
 
   def new
-    redirect_to "/"
+    if auth_session = authenticated?
+      if auth_session.user.role == "admin"
+        return redirect_to admin_dashboard_path
+      elsif auth_session.user.role == "standard"
+        return redirect_to "/"
+      end
+    end
+
+    render inertia: { create_session_path: session_path } # can add ",clear_history: true" as an option
+    # and it kind of does what I want. Does not navigate signed out user to a page requiring auth
+    # if they press the back button after logging out, however it does change the url to the previously visited auth route?
   end
 
   def create

--- a/app/frontend/components/Flash.tsx
+++ b/app/frontend/components/Flash.tsx
@@ -34,7 +34,10 @@ export function Flash() {
             );
           if (k === "alert") {
             return (
-              <p key={idx} className="border-red-600 p-4">
+              <p
+                key={idx}
+                className="border-red-600 border-2 p-4 rounded-2xl bg-red-400"
+              >
                 {String(v)}
               </p>
             );

--- a/app/frontend/components/FormErrorsDisplay.tsx
+++ b/app/frontend/components/FormErrorsDisplay.tsx
@@ -12,7 +12,7 @@ export function FormErrorsDisplay() {
   return (
     <>
       {Array.isArray(errors) && errors.length > 0 ? (
-        <div className="border-red-600 border-2 p-4 rounded-2xl bg-red-100">
+        <div className="border-red-600 border-2 p-4 rounded-2xl bg-red-400">
           {errors.map((err) => {
             return <p key={err}>{err}</p>;
           })}

--- a/app/frontend/layouts/Layout.tsx
+++ b/app/frontend/layouts/Layout.tsx
@@ -1,15 +1,30 @@
-import { Head } from "@inertiajs/react";
+import { Head, usePage, Link, Form } from "@inertiajs/react";
 
 import { Flash } from "@/components/Flash";
 import { FormErrorsDisplay } from "@/components/FormErrorsDisplay";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
+  const { props } = usePage<{
+    auth: { user: { user_id: number; email_address: string } };
+  }>();
+
   return (
     <>
       <Head title="Gomi guessing" />
       <header className="flex gap-1 justify-between flex-wrap items-center bg-amber-500 p-1.5">
-        <a>Gomi home</a>
-        <nav>Nav</nav>
+        <nav className="flex justify-between flex-1">
+          <div>
+            <Link href="/">Gomi home</Link>
+          </div>
+          <div className="flex gap-3">
+            Nav
+            {props.auth ? (
+              <Form method="delete" action="/session">
+                <button type="submit">Logout</button>
+              </Form>
+            ) : null}
+          </div>
+        </nav>
       </header>
       <main className="h-[calc(100vh-36px)] w-full flex flex-col items-center p-2">
         <Flash />

--- a/app/frontend/layouts/Layout.tsx
+++ b/app/frontend/layouts/Layout.tsx
@@ -1,4 +1,4 @@
-import { Head, usePage, Link, Form } from "@inertiajs/react";
+import { Head, usePage, Link, Form, router } from "@inertiajs/react";
 
 import { Flash } from "@/components/Flash";
 import { FormErrorsDisplay } from "@/components/FormErrorsDisplay";
@@ -20,7 +20,9 @@ export default function Layout({ children }: { children: React.ReactNode }) {
             Nav
             {props.auth ? (
               <Form method="delete" action="/session">
-                <button type="submit">Logout</button>
+                <button type="submit" onClick={() => router.clearHistory()}>
+                  Logout
+                </button>
               </Form>
             ) : null}
           </div>

--- a/app/frontend/pages/admin/dashboard/index.tsx
+++ b/app/frontend/pages/admin/dashboard/index.tsx
@@ -1,8 +1,22 @@
-export default function AdminDashboard() {
+import LinkBtn from "@/components/LinkBtn";
+
+interface DashboardProps {
+  prefectures_path: string;
+  items_path: string;
+}
+
+export default function AdminDashboard({
+  prefectures_path,
+  items_path,
+}: DashboardProps) {
   return (
     <>
       <div>
         <h1>Admin dashboard</h1>
+        <div>
+          <LinkBtn href={prefectures_path}>Prefectures</LinkBtn>
+          <LinkBtn href={items_path}>Items</LinkBtn>
+        </div>
       </div>
     </>
   );

--- a/app/frontend/pages/home/index.tsx
+++ b/app/frontend/pages/home/index.tsx
@@ -1,0 +1,9 @@
+export default function HomePage() {
+  return (
+    <>
+      <div>
+        <h1>Landing page</h1>
+      </div>
+    </>
+  );
+}

--- a/app/frontend/pages/sessions/new.tsx
+++ b/app/frontend/pages/sessions/new.tsx
@@ -1,0 +1,44 @@
+import { Form } from "@inertiajs/react";
+
+// import type { InertiaResponse } from "@/types/api";
+import LinkBtn from "@/components/LinkBtn";
+import BackBanner from "@/components/BackBanner";
+
+interface Props {
+  create_session_path: string;
+}
+
+export default function Login({ create_session_path }: Props) {
+  return (
+    <div className="flex flex-col w-full items-center gap-2">
+      <BackBanner>
+        <LinkBtn href="/">Back to home</LinkBtn>
+      </BackBanner>
+      <section className="flex flex-col gap-2">
+        <Form action={create_session_path} method="post">
+          <div className="flex flex-col">
+            <label className="flex flex-col">
+              Email:
+              <input
+                name="email_address"
+                type="email"
+                autoComplete="username"
+              />
+            </label>
+            <label className="flex flex-col">
+              Password:
+              <input
+                type="password"
+                // minLength={12}
+                maxLength={72}
+                name="password"
+                autoComplete="current-password"
+              />
+            </label>
+          </div>
+          <button type="submit">Submit</button>
+        </Form>
+      </section>
+    </div>
+  );
+}

--- a/app/frontend/pages/sessions/new.tsx
+++ b/app/frontend/pages/sessions/new.tsx
@@ -29,7 +29,7 @@ export default function Login({ create_session_path }: Props) {
               Password:
               <input
                 type="password"
-                // minLength={12}
+                minLength={12}
                 maxLength={72}
                 name="password"
                 autoComplete="current-password"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   resources :prefectures
   resources :municipalities
   resources :items
-  resource :session, only: [ :new ]
+  resource :session, only: [ :new, :create, :destroy ]
   resources :passwords, param: :token, only: [ :new ]
   inertia "/" => "Landing"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,8 @@ Rails.application.routes.draw do
   resources :items
   resource :session, only: [ :new, :create, :destroy ]
   resources :passwords, param: :token, only: [ :new ]
-  inertia "/" => "Landing"
+
+  get "/", to: "home#index"
 
   namespace "admin" do
     resources :items

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -18,4 +18,7 @@ export default defineConfig([
       "react/react-in-jsx-scope": "off",
     },
   },
+  {
+    rules: { "react/prop-types": "off" },
+  },
 ]);


### PR DESCRIPTION
### What changed, and _why_?
Added ability to sign in at `/session/new` endpoint, and put admin pages behind auth. If a user is not authenticated and tries to visit an admin page, they get redirected to `/session/new`.

### Screenshots (if relevant)

### Any other considerations
I didn't create a script to create a user, so plan to run the rails console with `kamal` to create a user on the prod vps.

#### Session Fixation
Session fixation stuff that I might try to implement later:
- https://edgeguides.rubyonrails.org/security.html#session-fixation-countermeasures
- https://stackoverflow.com/questions/4812813/rails-login-reset-session
- https://owasp.org/www-community/attacks/Session_fixation

#### Inertia History Encryption
Currently, if a user signs in and visits an admin page, then signs out, and finally presses the back button, they will not be navigated back to the previously shown admin page, but the url will change to the admin page. I had to add a click handler on the button that sends a DELETE request to log the user out to call `router.clearData()` to get this behavior. Without the call, the user would actually see the admin page they were on before logging out. Some things I found that seemed relevant to figuring out what was going on:
- https://github.com/inertiajs/inertia/pull/1784
- https://inertia-rails.dev/guide/history-encryption - note that this should be configured on in the app, but it doesn't seem like it's actually being enabled
- https://github.com/inertiajs/inertia/discussions/769#discussioncomment-16547578
- https://www.youtube.com/watch?v=gTMX4JM_-0E