### PR TITLE
Migrate to gomi-guesser subdomain

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -19,9 +19,7 @@ servers:
 # Note: If using Cloudflare, set encryption mode in SSL/TLS setting to "Full" to enable CF-to-app encryption.
 proxy:
   ssl: false
-  hosts:
-    - www.sunasuna.cafe
-    - sunasuna.cafe
+  host: gomi-guesser.sunasuna.cafe
   app_port: 3000
 
 # Credentials for your image host.

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -39,7 +39,7 @@ env:
   clear:
     # Run the Solid Queue Supervisor inside the web server's Puma process to do jobs.
     # When you start using multiple servers, you should split out job processing to a dedicated machine.
-    SOLID_QUEUE_IN_PUMA: true # i don't want to use solid queue, etc i think
+    SOLID_QUEUE_IN_PUMA: false # i don't want to use solid queue, etc i think
 
     # Set number of processes dedicated to Solid Queue (default: 1)
     # JOB_CONCURRENCY: 3


### PR DESCRIPTION
### What changed, and _why_?
This changes config in `config/deploy.yml` to tell kamal proxy to only accept requests that have `gomi-guesser.sunasuna.cafe` as the host (through headers perhaps? Unsure because later http versions don't send the `host` header I thought). It also tries to disable `solid queue` by setting `env.clear.SOLID_QUEUE_IN_PUMA = false`, though I'm not sure this actually disables it.

In addition to code changes captured here, I had to update dns to point the `gomi-guesser` subdomain to the vps by setting an A record, and also remove A records pointing to `www.sunasuna.cafe` and `sunasuna.cafe`.

Also had to ssh into the vps to change nginx config - removed server blocks for `snacc-tracc` (another app that was being hosted on the vps with docker swarm, chose to take it down for now since it hasn't been developed at all) as well as bare `sunasuna.cafe` server block. I also removed certbot generated tls certs by running `certbot delete`, and added a new cert for the `gomi-guesser` server block.

### Screenshots (if relevant)

### Any other considerations
Might be worth adding the nginx config used for the vps to source control, especially if we want to include it automation somehow.