### PR TITLE
Sets root route as "/"

### DIFF
--- a/app/frontend/pages/sessions/new.tsx
+++ b/app/frontend/pages/sessions/new.tsx
@@ -29,7 +29,7 @@ export default function Login({ create_session_path }: Props) {
               Password:
               <input
                 type="password"
-                minLength={12}
+                // minLength={12}
                 maxLength={72}
                 name="password"
                 autoComplete="current-password"

--- a/app/frontend/pages/sessions/new.tsx
+++ b/app/frontend/pages/sessions/new.tsx
@@ -29,7 +29,6 @@ export default function Login({ create_session_path }: Props) {
               Password:
               <input
                 type="password"
-                // minLength={12}
                 maxLength={72}
                 name="password"
                 autoComplete="current-password"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,5 +40,5 @@ Rails.application.routes.draw do
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
 
   # Defines the root path route ("/")
-  # root "posts#index"
+  root "home#index"
 end


### PR DESCRIPTION
### What changed, and _why_?
After deploying [this PR](https://github.com/kinoko-empire/gomi_guesser/pull/68) to add auth, realized that `root_url` that is being used as a fallback when routing a user after authenticating (see the `after_authentication_url` method in `app/controllers/concerns/authentication.rb`) was an undefined method, causing a 500 error. I noticed that trying to directly visit `/session/new` and signing in would raise the error which makes sense.

The fix was to define a root path in `routes.rb`, and in this case I made the fallback route to `home#index` aka `"/"`. I also removed the character minimum on the password field for the `/session/new` page as it is not being used for sign up, only sign in.

### Screenshots (if relevant)

### Any other considerations
