### PR TITLE
Adds current nginx config to repo

### DIFF
--- a/config/nginx/gomi-guesser.sunasuna.cafe.conf
+++ b/config/nginx/gomi-guesser.sunasuna.cafe.conf
@@ -1,0 +1,55 @@
+# https://wiki.debian.org/Nginx/DirectoryStructure
+#
+# In most cases, administrators will remove this file from sites-enabled/ and
+# leave it as reference inside of sites-available where it will continue to be
+# updated by the nginx packaging team.
+#
+# This file will automatically load configuration files provided by other
+# applications, such as Drupal or Wordpress. These applications will be made
+# available underneath a path with that package name, such as /drupal8.
+#
+# Please see /usr/share/doc/nginx-doc/examples/ for more detailed examples.
+##
+
+# Default server configuration
+#
+
+server {
+        index index.htm index.nginx-debian.html index.html;
+        server_name gomi-guesser.sunasuna.cafe;
+
+        access_log /var/log/nginx/gomi-guesser.sunasuna.cafe.access.log;
+        error_log /var/log/nginx/gomi-guesser.sunasuna.cafe.error.log;
+
+        location / {
+                # First attempt to serve request as file, then
+                # as directory, then fall back to displaying a 404.
+                # try_files $uri $uri/ =404;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header Host $host;
+                proxy_pass http://127.0.0.1:8080/;
+        }
+
+
+    listen 443 ssl; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/gomi-guesser.sunasuna.cafe/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/gomi-guesser.sunasuna.cafe/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+
+}
+
+
+server {
+    if ($host = gomi-guesser.sunasuna.cafe) {
+        return 301 https://$host$request_uri;
+    } # managed by Certbot
+
+
+        server_name gomi-guesser.sunasuna.cafe;
+    listen 80;
+    return 404; # managed by Certbot
+
+
+}


### PR DESCRIPTION
### What changed, and _why_?
I added the nginx config saved in `/etc/nginx/conf.d/gomi-guesser.sunasuna.cafe.conf` to the repo to save it in source control. The Digital Ocean droplet that gomi-guesser runs on is around $7/month and is located in the US east region and at the moment I'm located in Tokyo, Japan so the request times got a little bit slower. Might try to migrate this to a React SPA on AWS to save on costs.

### Screenshots (if relevant)

### Any other considerations
